### PR TITLE
fix: ctx.model.ctx injection

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -30,7 +30,7 @@ module.exports = class BootHook {
   async willReady() {
     const { app } = this;
     const config = app.config.orm;
-    const databases = (config.datasources || [config])
+    const databases = (config.datasources || [ config ])
       .map(datasource => loadDatabase(app, { ...defaultConfig, ...datasource }));
     await Promise.all(databases.map(authenticate));
   }
@@ -39,8 +39,6 @@ module.exports = class BootHook {
 
 function injectContext(app, delegate) {
   const RPOXY = Symbol('egg-orm:proxy');
-  const CTX = Symbol('egg-orm:ctx');
-  const ORIGINAL_MODEL_CLASS_NAME = Symbol('egg-orm:original_model_class_name');
   const realm = app[delegate];
   const { Model } = realm;
 
@@ -50,6 +48,10 @@ function injectContext(app, delegate) {
 
       const ctx = this;
       const proxy = new Proxy(realm, {
+        get ctx() {
+          return ctx;
+        },
+
         get(target, property) {
           const injected = this[property];
           if (injected) return injected;
@@ -61,24 +63,14 @@ function injectContext(app, delegate) {
           }
 
           class ContextModelClass extends OriginModelClass {
-            constructor(opts) {
-              super(opts);
-              this[ORIGINAL_MODEL_CLASS_NAME] = property;
-            }
-
             // custom setter always execute before define [CTX] when new Instance(super(opts) calling), if custom setter requires ctx, it should not be undefined
             get ctx() {
               return ctx;
             }
-            get $originalModelName() {
-              return this[ORIGINAL_MODEL_CLASS_NAME];
+            static get ctx() {
+              return ctx;
             }
           }
-          Object.defineProperty(ContextModelClass, 'ctx', {
-            get() {
-              return ctx;
-            },
-          });
           // stash injected class onto ctx.model
           this[property] = ContextModelClass;
           return ContextModelClass;

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -108,7 +108,18 @@ function loadDatabase(app, config) {
     },
   });
 
-  for (const model of models) realm[model.name] = model;
+  for (const model of models) {
+    // make `fullPath` and `pathName` not enumerable to ignore them when serialize
+    for (const key of [ 'fullPath', 'pathName' ]) {
+      if (model[key] != null) {
+        Object.defineProperty(model.prototype, key, {
+          value: model[key],
+          enumerable: false,
+        });
+      }
+    }
+    realm[model.name] = model;
+  }
   app[config.delegate].Model = Model;
   injectContext(app, config.delegate);
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "author": "Chen Yangjian <yicai.cyj@alibaba-inc.com>",
   "license": "MIT",
   "dependencies": {
-    "leoric": "^1.0.0"
+    "leoric": "^1.4.0-alpha.3"
   },
   "devDependencies": {
     "egg": "^2.25.0",

--- a/test/delegate.test.js
+++ b/test/delegate.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const assert = require('assert');
+const assert = require('assert').strict;
 const mm = require('egg-mock');
 
 describe('test/delegate.test.js', () => {
@@ -30,6 +30,8 @@ describe('test/delegate.test.js', () => {
 
     it('should be accessible via ctx.orm', () => {
       assert(ctx.orm);
+      assert(ctx.orm.ctx === ctx);
+
       // access twice to make sure avoiding duplicated injection
       const User = ctx.orm.User;
       assert(ctx.orm.User === User);

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const assert = require('assert');
+const assert = require('assert').strict;
 const mm = require('egg-mock');
 
 describe('test/plugin.test.js', () => {


### PR DESCRIPTION
methods like `ctx.model.query` might require `ctx.model.ctx` to be available to log meaningful contents on context