### PR TITLE
fix: ignore properties inject by egg loader

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -99,10 +99,13 @@ function loadDatabase(app, config) {
   for (const model of models) {
     // make `fullPath` and `pathName` not enumerable to ignore them when serialize
     for (const key of [ 'fullPath', 'pathName' ]) {
-      if (model[key] != null) {
+      const descriptor = Object.getOwnPropertyDescriptor(model.prototype, key);
+      if (descriptor && typeof descriptor.value === 'string') {
         Object.defineProperty(model.prototype, key, {
-          value: model[key],
+          ...descriptor,
+          writable: true,
           enumerable: false,
+          configurable: true,
         });
       }
     }

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -124,6 +124,9 @@ describe('test/plugin.test.js', () => {
       assert(res.body.nickname === 'jack');
       assert(res.body.email === 'jack@example.com');
       assert(res.body.createdAt);
+      // should ignore properties injected by egg loader
+      assert(res.body.fullPath == null);
+      assert(res.body.pathName == null);
 
       // should not interfere JSON dump
       assert(res.body.hasOwnProperty('ctx') === false);


### PR DESCRIPTION
the file loader provided by egg-core will inject `pathName` and `fullPath` into module exports, even into class prototype if that's what is exported.

- https://github.com/eggjs/egg-core/blob/master/lib/loader/file_loader.js#L163