### PR TITLE
fix: `Model.name` should be consistent

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -48,11 +48,14 @@ function injectContext(app, delegate) {
           }
 
           class ContextModelClass extends OriginModelClass {
-            // custom setter always execute before define [CTX] when new Instance(super(opts) calling), if custom setter requires ctx, it should not be undefined
-            get ctx() {
-              return ctx;
+            static get name() {
+              return super.name;
             }
             static get ctx() {
+              return ctx;
+            }
+            // custom setter always execute before define [CTX] when new Instance(super(opts) calling), if custom setter requires ctx, it should not be undefined
+            get ctx() {
               return ctx;
             }
           }

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -44,6 +44,10 @@ describe('test/plugin.test.js', () => {
       const ctxModel = ctx.model;
       assert(ctx.model === ctxModel);
       assert(ctx.model.User.ctx === ctx);
+      assert((new ctx.model.User()).ctx === ctx);
+      assert(ctx.model.User.app);
+      assert((new ctx.model.User()).app);
+      assert(ctx.model.User.name === 'User');
 
       const user = ctx.model.User.build({
         nickname: 'foo nickname',


### PR DESCRIPTION
`ctx.model.User` is subclass of `app.model.User`, which should share the same `Model.name`