### PR TITLE
feat: support tegg-egg mixing mode

### DIFF
--- a/examples/typescript/basic/config/plugin.ts
+++ b/examples/typescript/basic/config/plugin.ts
@@ -1,0 +1,11 @@
+
+export default {
+  tegg: {
+    package: '@eggjs/tegg-plugin',
+    enable: true,
+  },
+  teggConfig: {
+    package: '@eggjs/tegg-config',
+    enable: true,
+  },
+};

--- a/examples/typescript/basic/modules/test-module/helloService.ts
+++ b/examples/typescript/basic/modules/test-module/helloService.ts
@@ -1,0 +1,18 @@
+
+import { ContextProto, AccessLevel } from '@eggjs/tegg';
+import User from '../../app/model/user';
+
+import InjectModel from './util';
+
+@ContextProto({
+  accessLevel: AccessLevel.PUBLIC,
+})
+export default class HelloService {
+  @InjectModel()
+  private readonly User: typeof User;
+
+  async sayHello(id: number) {
+    const user = await this.User.findOne(id);
+    return `hello ${user.nickname}`;
+  }
+}

--- a/examples/typescript/basic/modules/test-module/package.json
+++ b/examples/typescript/basic/modules/test-module/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "test-module",
+  "description": "test module",
+  "eggModule": {
+    "name": "testModule"
+  }
+}

--- a/examples/typescript/basic/modules/test-module/util.ts
+++ b/examples/typescript/basic/modules/test-module/util.ts
@@ -1,0 +1,34 @@
+
+import { Inject } from '@eggjs/tegg';
+import { IModel } from 'egg';
+
+export type InjectParam = {
+  name?: keyof IModel;
+};
+
+function injectFactory(targetKey, targetName) {
+  return (param?: InjectParam) => (target, key: string) => {
+    if (!target[targetKey]) {
+      Inject({ name: targetName })(target, targetKey);
+    }
+
+    Object.defineProperty(target, targetKey, {
+      enumerable: false,
+      configurable: false,
+    });
+
+    Object.defineProperty(target, key, {
+      get() {
+        return this[targetKey][param?.name || key];
+      },
+      enumerable: true,
+      configurable: true,
+    });
+  }
+}
+
+const modelMetaKey = Symbol.for('model');
+
+export default function InjectModel(param?: InjectParam){
+  return injectFactory(modelMetaKey, 'model')(param);
+}

--- a/examples/typescript/basic/types/index.d.ts
+++ b/examples/typescript/basic/types/index.d.ts
@@ -1,5 +1,9 @@
+import 'egg';
+
 import Post from '../app/model/post';
 import User from '../app/model/user';
+import HelloService from '../modules/test-module/helloService';
+
 
 declare module 'egg' {
   interface IModel {
@@ -14,5 +18,11 @@ declare module 'egg' {
   // extend context
   interface Context {
     model: IModel;
+  }
+
+  export interface EggModule {
+    hello: {
+      helloService: HelloService;
+    }
   }
 }

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -6,19 +6,24 @@ const Realm = require('leoric');
 module.exports = class BootHook {
   constructor(app) {
     this.app = app;
+    this.databases = [];
   }
 
-  // init database in willReady so developer can change the config in didLoad method
-  async willReady() {
+  // load models to app in didLoad so that tegg can read the delegate in app/context
+  // developer can change the config in configDidLoad method
+  async didLoad() {
     const { app } = this;
     const config = app.config.orm;
     const datasources = config.datasources || [ config ];
     // Make multiple copies of Bone to support multiple databases, otherwise use Bone directly
     const subclass = datasources.length > 1;
-    const databases = datasources.map(datasource => {
+    this.databases = datasources.map(datasource => {
       return loadDatabase(app, { subclass, ...datasource });
     });
-    await Promise.all(databases.map(authenticate));
+  }
+
+  async willReady() {
+    await Promise.all(this.databases.map(authenticate));
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.17.0",
+    "@eggjs/tegg": "^1.4.0",
+    "@eggjs/tegg-config": "^1.2.1",
+    "@eggjs/tegg-plugin": "^1.3.8",
     "@types/mocha": "^9.1.0",
     "egg": "^2.25.0",
     "egg-bin": "^4.14.0",

--- a/test/typescript/basic.test.ts
+++ b/test/typescript/basic.test.ts
@@ -166,4 +166,21 @@ describe('test/typesript/basic/plugin.test.ts', () => {
       assert.deepEqual(res2.body, res.body);
     });
   });
+
+  describe('tegg-module-mixing', () => {
+    it('should work', async () => {
+      const ctx = await app.mockModuleContext();
+
+      const user = await ctx.model.User.create({
+        nickname: 'jerry',
+        email: 'jerry@example.com',
+      });
+
+      assert.ok(user);
+
+      const res =  await ctx.module.testModule.helloService.sayHello(user.id);
+
+      assert.equal(res, 'hello jerry');
+    });
+  });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -18,7 +18,16 @@ declare class MySequelizeBone extends SequelizeBone {
 
 }
 
-export { MySequelizeBone as SequelizeBone }
+declare class MyBone extends Bone {
+  static ctx: Context;
+  static app: Application;
+
+  ctx: Context;
+  app: Application;
+
+}
+
+export { MySequelizeBone as SequelizeBone, MyBone as Bone }
 
 interface EggOrmOptions extends ConnectOptions {
   delegate?: string;


### PR DESCRIPTION
Supporting inject model to tegg modules form `ctx.model`
```ts
import { ContextProto, AccessLevel } from '@eggjs/tegg';
import User from '../../app/model/user';

import InjectModel from './util';

@ContextProto({
  accessLevel: AccessLevel.PUBLIC,
})
export default class HelloService {
  @InjectModel()
  private readonly User: typeof User;

  async sayHello(id: number) {
    const user = await this.User.findOne(id);
    return `hello ${user.nickname}`;
  }
}

```