### PR TITLE
fix: rewire prototype of models when subclassing is enabled

### DIFF
--- a/examples/sequelize/app/model/comment.js
+++ b/examples/sequelize/app/model/comment.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const { DataTypes: { BIGINT, TEXT } } = require('../../../..');
+const Base = require('./common/base');
+
+module.exports = class Comment extends Base {
+  static attributes = {
+    id: { type: BIGINT, primaryKey: true, autoIncrement: true },
+    content: { type: TEXT },
+    userId: { type: BIGINT, allowNull: false },
+  };
+};

--- a/examples/sequelize/app/model/common/base.js
+++ b/examples/sequelize/app/model/common/base.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const { Bone } = require('../../../../..');
+
+module.exports = class Base extends Bone {
+  static shardingKey = 'userId';
+};

--- a/examples/sequelize/app/model/post.js
+++ b/examples/sequelize/app/model/post.js
@@ -6,6 +6,7 @@ module.exports = function(app) {
     id: { type: BIGINT, autoIncrement: true },
     content: TEXT,
     description: STRING,
+    userId: { type: BIGINT, allowNull: false },
   });
   return Post;
 };

--- a/examples/sequelize/app/model/user.js
+++ b/examples/sequelize/app/model/user.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = (app) => {
+module.exports = app => {
   const { Bone, DataTypes: { STRING, DATE } } = app.model;
 
   class User extends Bone {
@@ -8,7 +8,7 @@ module.exports = (app) => {
       nickname: { type: STRING, allowNull: false },
       email: { type: STRING, allowNull: true },
       createdAt: { type: DATE },
-    }
+    };
   }
 
   return User;

--- a/examples/sequelize/config/config.js
+++ b/examples/sequelize/config/config.js
@@ -4,6 +4,7 @@ exports.orm = {
   database: 'egg-orm',
   sequelize: true,
   port: process.env.MYSQL_PORT,
+  exclude: 'common',
 };
 
 exports.keys = 'hello';

--- a/examples/typescript/sequelize/app/model/comment.ts
+++ b/examples/typescript/sequelize/app/model/comment.ts
@@ -1,0 +1,13 @@
+import { Column, DataTypes } from '../../../../..';
+import Base from './common/base';
+
+export default class Comment extends Base {
+  @Column({ primaryKey: true, autoIncrement: true })
+  id: bigint;
+  
+  @Column(DataTypes.TEXT)
+  content: string;
+
+  @Column({ allowNull: false })
+  userId: bigint;
+};

--- a/examples/typescript/sequelize/app/model/common/base.ts
+++ b/examples/typescript/sequelize/app/model/common/base.ts
@@ -1,0 +1,5 @@
+import { SequelizeBone } from '../../../../../..';
+
+export default class Base extends SequelizeBone {
+  static shardingKey = 'userId';
+};

--- a/examples/typescript/sequelize/config/config.ts
+++ b/examples/typescript/sequelize/config/config.ts
@@ -2,6 +2,7 @@ export default {
   orm: {
     database: 'egg-orm',
     port: process.env.MYSQL_PORT,
+    exclude: 'common',
   },
 
   keys: 'hello',

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -130,10 +130,15 @@ function loadDatabase(app, config) {
       }
       if (!Realm.isBone(factory)) return;
 
-      // module.exports = class User extends require('leoric').Bone;
-      if (!(factory.prototype instanceof Model)) {
-        Object.setPrototypeOf(factory, Model);
-        Object.setPrototypeOf(factory.prototype, Object.create(Model.prototype));
+      // class User extends require('leoric').Bone;
+      // class User extends (class extends require('leoric').Bone {});
+      let klass = factory;
+      while (Object.getPrototypeOf(klass) !== Realm.Bone) {
+        klass = Object.getPrototypeOf(klass);
+      }
+      if (klass !== Model && !(klass instanceof Model)) {
+        Object.setPrototypeOf(klass, Model);
+        Object.setPrototypeOf(klass.prototype, Object.create(Model.prototype));
       }
 
       const name = factory.name;

--- a/test/dumpfile.sql
+++ b/test/dumpfile.sql
@@ -1,5 +1,6 @@
 DROP TABLE IF EXISTS `users`;
 DROP TABLE IF EXISTS `posts`;
+DROP TABLE IF EXISTS `comments`;
 
 CREATE TABLE `users` (
   `id` bigint(20) AUTO_INCREMENT PRIMARY KEY,
@@ -15,3 +16,9 @@ CREATE TABLE `posts` (
   `description` varchar(256) NOT NULL,
   `user_id` bigint(20)
 );
+
+CREATE TABLE `comments` (
+  `id` bigint(20) AUTO_INCREMENT PRIMARY KEY,
+  `content` TEXT,
+  `user_id` bigint(20)
+)

--- a/test/sequelize.test.js
+++ b/test/sequelize.test.js
@@ -112,6 +112,17 @@ describe('test/sequelize.test.js', () => {
     });
   });
 
+  describe('sequelize', () => {
+    it('should extend Bone with sequelize methods', () => {
+      assert.equal(typeof app.model.User.findAll, 'function');
+    });
+
+    it('should be able to handle multiple inheritance', async () => {
+      assert.equal(app.model.Comment.shardingKey, 'userId');
+      assert.equal(typeof app.model.Comment.findAll, 'function');
+    });
+  });
+
   describe('GET /users/:id, POST /users', () => {
     beforeEach(async function() {
       await app.model.User.truncate();

--- a/test/typescript/sequelize.test.ts
+++ b/test/typescript/sequelize.test.ts
@@ -45,6 +45,11 @@ describe('test/typescript/sequelize/plugin.test.ts', () => {
     it('should extend Bone with sequelize methods', () => {
       assert.equal(typeof app.model.User.findAll, 'function');
     });
+
+    it('should be able to handle multiple inheritance', async () => {
+      assert.equal(app.model.Comment.shardingKey, 'userId');
+      assert.equal(typeof app.model.Comment.findAll, 'function');
+    });
   });
 
   describe('ctx.model', () => {


### PR DESCRIPTION
realm.Bone will be a subclass of Realm.Bone in following cases:

```js
new Realm({ sequelize: true });
new Realm({ subclass: true }); // which will be turned on when multiple databases are needed
new Realm({ Bone: class extends Realm.Bone });
```

in those scenarios, models authorized with `class Foo extends Realm.Bone {}` need to have their prototypes updated to realm.Bone instead.